### PR TITLE
feat: 인스타 크롤링, S3에 이미지 업로드 구현

### DIFF
--- a/python-server/.gitignore
+++ b/python-server/.gitignore
@@ -2,3 +2,8 @@ venv/
 .env
 __pycache__/
 *.pyc
+crawler/cookies/
+
+.venv/
+env/
+ENV/

--- a/python-server/README.md
+++ b/python-server/README.md
@@ -1,9 +1,11 @@
-📘 Instagram Crawler Flask Server – Setup Guide
-
-이 문서는 Instagram 게시물 이미지 크롤링 → S3 업로드를 수행하는
+이 문서는 Instagram 게시물 이미지 크롤링 → S3 업로드를 수행하는  
 Flask 기반 python-server 실행 방법을 정리한 가이드입니다.
 
-📁 프로젝트 구조
+---
+
+## 프로젝트 구조
+
+```
 python-server/
  ├── app.py
  ├── services/
@@ -12,61 +14,87 @@ python-server/
  │    ├── instagram_crawler.py
  │    ├── image_downloader.py
  │    └── cookies/
- │          └── prod_cookies.json   (🚫 Git 미포함)
+ │          └── prod_cookies.json   (Git 미포함)
  ├── aws/
  │    └── s3_utils.py
  ├── requirements.txt
- ├── .env                (🚫 Git 미포함)
+ ├── .env                (Git 미포함)
  └── venv/               (로컬 가상환경, Git 미포함)
+```
 
-⚠️ 사전 요구사항
-✔ Python 3.11.x 필수
+---
 
-undetected-chromedriver는 Python 3.12 미지원이므로
-반드시 Python 3.11 버전으로 실행해야 합니다.
+## 사전 요구사항
+
+### 1) Python 3.11.x 필수  
+undetected-chromedriver는 Python 3.12를 지원하지 않기 때문에  
+반드시 Python 3.11 버전을 사용해야 합니다.
 
 macOS 설치 명령어:
 
+```
 brew install python@3.11
+```
 
-✔ Chrome 브라우저 설치
+---
 
+### 2) Chrome 브라우저 설치  
 undetected-chromedriver는 Chrome 기반으로 동작합니다.
 
-✔ AWS IAM User (S3 업로드용)
+---
 
-Access Key / Secret Key 필요합니다.
+### 3) AWS IAM User 
+Access Key / Secret Key가 필요합니다.
 
-✔ Instagram 로그인 쿠키 필요 (중요)
+---
 
-로그인하지 않은 계정으로는
-슬라이드 이미지 전체를 가져올 수 없기 때문에
-쿠키 파일이 반드시 필요합니다.
+### 4) Instagram 로그인 쿠키 필요  
+로그인하지 않은 계정으로는 슬라이드 이미지 전체를 수집할 수 없습니다.  
+따라서 로그인 쿠키가 반드시 필요합니다.
 
 쿠키 파일 위치:
 
-python-server/crawler/cookies/prod_cookies.json
+```
+python-server/crawler/cookies/cookies.json
+```
 
+이 파일은 Git에 포함되지 않으며 팀 노션에 업로드되어 있습니다.
 
-🚫 Git에 포함되지 않으며, 팀 노션에 업로드되어 있습니다.
+---
 
-🛠 실행 방법
-1) Python 3.11 기반 가상환경 생성
+## 실행 방법
+
+### 1) Python 3.11 기반 가상환경 생성
+
+```
 python3.11 -m venv venv
 source venv/bin/activate
-
+```
 
 Windows:
 
+```
 venv\Scripts\activate
+```
 
-2) 패키지 설치
+---
+
+### 2) 패키지 설치
+
+```
 pip install -r requirements.txt
+```
 
-3) venv 안에서 서버 실행
+---
+
+### 3) 서버 실행
+
+```
 python app.py
+```
 
-
-기본 포트:
-
+기본 포트:  
 http://localhost:9000
+
+---
+

--- a/python-server/README.md
+++ b/python-server/README.md
@@ -1,9 +1,11 @@
+# 📘 Instagram Crawler Flask Server – Setup Guide
+
 이 문서는 Instagram 게시물 이미지 크롤링 → S3 업로드를 수행하는  
 Flask 기반 python-server 실행 방법을 정리한 가이드입니다.
 
 ---
 
-## 프로젝트 구조
+## 📁 프로젝트 구조
 
 ```
 python-server/
@@ -24,7 +26,7 @@ python-server/
 
 ---
 
-## 사전 요구사항
+## ⚠️ 사전 요구사항
 
 ### 1) Python 3.11.x 필수  
 undetected-chromedriver는 Python 3.12를 지원하지 않기 때문에  
@@ -58,7 +60,7 @@ Access Key / Secret Key가 필요합니다.
 python-server/crawler/cookies/cookies.json
 ```
 
-이 파일은 Git에 포함되지 않으며 팀 노션에 업로드되어 있습니다.
+Git에 포함되지 않은 파일들은 팀 노션에 업로드되어 있습니다.
 
 ---
 

--- a/python-server/README.md
+++ b/python-server/README.md
@@ -1,3 +1,8 @@
+📘 Instagram Crawler Flask Server – Setup Guide
+
+이 문서는 Instagram 게시물 이미지 크롤링 → S3 업로드를 수행하는
+Flask 기반 python-server 실행 방법을 정리한 가이드입니다.
+
 📁 프로젝트 구조
 python-server/
  ├── app.py
@@ -15,36 +20,41 @@ python-server/
  └── venv/               (로컬 가상환경, Git 미포함)
 
 ⚠️ 사전 요구사항
-✔ Python 3.11.x
+✔ Python 3.11.x 필수
 
-반드시 Python 3.11 사용해야 합니다.
-undetected-chromedriver는 Python 3.12를 지원하지 않습니다.
+undetected-chromedriver는 Python 3.12 미지원이므로
+반드시 Python 3.11 버전으로 실행해야 합니다.
 
-macOS 설치 방법:
+macOS 설치 명령어:
 
 brew install python@3.11
 
 ✔ Chrome 브라우저 설치
 
-undetected-chromedriver는 Chrome 자동 실행이 필요합니다.
+undetected-chromedriver는 Chrome 기반으로 동작합니다.
 
-✔ AWS IAM User (S3 접근용)
+✔ AWS IAM User (S3 업로드용)
+
+Access Key / Secret Key 필요합니다.
 
 ✔ Instagram 로그인 쿠키 필요 (중요)
 
-로그인하지 않으면 슬라이드 이미지 전체를 볼 수 없기 때문에
+로그인하지 않은 계정으로는
+슬라이드 이미지 전체를 가져올 수 없기 때문에
 쿠키 파일이 반드시 필요합니다.
 
-파일 위치:
+쿠키 파일 위치:
 
-python-server/crawler/cookies/cookies.json
+python-server/crawler/cookies/prod_cookies.json
 
-🚫 Git에 포함되지 않으며 팀 노션에 업로드 해놨습니다.
+
+🚫 Git에 포함되지 않으며, 팀 노션에 업로드되어 있습니다.
 
 🛠 실행 방법
 1) Python 3.11 기반 가상환경 생성
 python3.11 -m venv venv
 source venv/bin/activate
+
 
 Windows:
 
@@ -55,4 +65,8 @@ pip install -r requirements.txt
 
 3) venv 안에서 서버 실행
 python app.py
-기본 포트: 9000
+
+
+기본 포트:
+
+http://localhost:9000

--- a/python-server/README.md
+++ b/python-server/README.md
@@ -1,0 +1,58 @@
+📁 프로젝트 구조
+python-server/
+ ├── app.py
+ ├── services/
+ │    └── crawler_service.py
+ ├── crawler/
+ │    ├── instagram_crawler.py
+ │    ├── image_downloader.py
+ │    └── cookies/
+ │          └── prod_cookies.json   (🚫 Git 미포함)
+ ├── aws/
+ │    └── s3_utils.py
+ ├── requirements.txt
+ ├── .env                (🚫 Git 미포함)
+ └── venv/               (로컬 가상환경, Git 미포함)
+
+⚠️ 사전 요구사항
+✔ Python 3.11.x
+
+반드시 Python 3.11 사용해야 합니다.
+undetected-chromedriver는 Python 3.12를 지원하지 않습니다.
+
+macOS 설치 방법:
+
+brew install python@3.11
+
+✔ Chrome 브라우저 설치
+
+undetected-chromedriver는 Chrome 자동 실행이 필요합니다.
+
+✔ AWS IAM User (S3 접근용)
+
+✔ Instagram 로그인 쿠키 필요 (중요)
+
+로그인하지 않으면 슬라이드 이미지 전체를 볼 수 없기 때문에
+쿠키 파일이 반드시 필요합니다.
+
+파일 위치:
+
+python-server/crawler/cookies/cookies.json
+
+🚫 Git에 포함되지 않으며 팀 노션에 업로드 해놨습니다.
+
+🛠 실행 방법
+1) Python 3.11 기반 가상환경 생성
+python3.11 -m venv venv
+source venv/bin/activate
+
+Windows:
+
+venv\Scripts\activate
+
+2) 패키지 설치
+pip install -r requirements.txt
+
+3) venv 안에서 서버 실행
+python app.py
+기본 포트: 9000

--- a/python-server/README.md
+++ b/python-server/README.md
@@ -16,7 +16,7 @@ python-server/
  │    ├── instagram_crawler.py
  │    ├── image_downloader.py
  │    └── cookies/
- │          └── prod_cookies.json   (Git 미포함)
+ │          └── cookies.json   (Git 미포함)
  ├── aws/
  │    └── s3_utils.py
  ├── requirements.txt
@@ -64,7 +64,7 @@ Git에 포함되지 않은 파일들은 팀 노션에 업로드되어 있습니�
 
 ---
 
-## 실행 방법
+## 🛠 실행 방법
 
 ### 1) Python 3.11 기반 가상환경 생성
 

--- a/python-server/app.py
+++ b/python-server/app.py
@@ -1,10 +1,26 @@
-from flask import Flask, jsonify
+# app.py
+from flask import Flask, request, jsonify
+from services.crawler_service import CrawlerService
+from dotenv import load_dotenv
+
+load_dotenv()
 
 app = Flask(__name__)
 
-@app.route("/health")
-def health():
-    return jsonify({"status": "ok"}), 200
+@app.route("/crawl", methods=["POST"])
+def crawl():
+    data = request.json
+    url = data.get("url")
+
+    if not url:
+        return jsonify({"error": "url is required"}), 400
+
+    try:
+        result = CrawlerService.crawl_and_upload(url)
+        return jsonify(result)
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    app.run(host="0.0.0.0", port=9000, debug=True)

--- a/python-server/aws/s3_utils.py
+++ b/python-server/aws/s3_utils.py
@@ -1,0 +1,21 @@
+# python-server/aws/s3_utils.py
+import boto3
+import os
+
+s3 = boto3.client(
+    "s3",
+    aws_access_key_id=os.getenv("AWS_ACCESS_KEY"),
+    aws_secret_access_key=os.getenv("AWS_SECRET_KEY"),
+    region_name=os.getenv("AWS_REGION")
+)
+
+BUCKET = os.getenv("S3_BUCKET_NAME")
+
+def upload_to_s3(data: bytes, key: str):
+    s3.put_object(
+        Bucket=BUCKET,
+        Key=key,
+        Body=data,
+        ContentType="image/jpeg"
+    )
+    print("[S3] uploaded:", key)

--- a/python-server/crawler/image_downloader.py
+++ b/python-server/crawler/image_downloader.py
@@ -1,0 +1,21 @@
+# python-server/crawler/downloader.py
+import requests
+from pathlib import Path
+from aws.s3_utils import upload_to_s3     # 새로 만든 S3 유틸
+
+def fetch_image_bytes(url: str) -> bytes:
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+    return response.content
+
+def download_and_upload_to_s3(url_list, prefix: str):
+    uploaded_keys = []
+
+    for idx, url in enumerate(url_list):
+        img_bytes = fetch_image_bytes(url)
+        key = f"{prefix}/image_{idx}.jpg"
+        upload_to_s3(img_bytes, key)
+        uploaded_keys.append(key)
+
+    return uploaded_keys
+

--- a/python-server/crawler/instagram_crawler.py
+++ b/python-server/crawler/instagram_crawler.py
@@ -1,0 +1,103 @@
+# python-server/crawler/instagram_crawler.py
+
+import json
+import time
+from pathlib import Path
+import undetected_chromedriver as uc
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+
+class InstagramCrawler:
+    def __init__(self, headless=True):
+        options = uc.ChromeOptions()
+        if headless:
+            options.add_argument("--headless=new")
+        options.add_argument("--disable-gpu")
+        options.add_argument("--no-sandbox")
+        options.add_argument("--disable-dev-shm-usage")
+
+        self.driver = uc.Chrome(options=options)
+
+    def load_cookies(self, cookie_path=None):
+        cookie_file = Path(cookie_path)
+        if not cookie_file.exists():
+            print("[WARN] Cookie file not found.")
+            return
+
+        cookies = json.loads(cookie_file.read_text())
+
+        domains = ["https://www.instagram.com/", "https://instagram.com/"]
+
+        for d in domains:
+            self.driver.get(d)
+            time.sleep(1)
+
+            for cookie in cookies:
+                cookie.pop("sameSite", None)
+                cookie.pop("expirationDate", None)
+
+                if cookie.get("domain") and cookie["domain"].startswith("."):
+                    cookie["domain"] = cookie["domain"][1:]
+                try:
+                    self.driver.add_cookie(cookie)
+                except:
+                    pass
+
+        self.driver.get("https://www.instagram.com/")
+        time.sleep(1)
+        print("[INFO] Cookies loaded")
+
+    def fetch_html(self, url: str) -> str:
+        print(f"[INFO] Fetching {url}")
+        self.driver.get(url)
+
+        try:
+            WebDriverWait(self.driver, 10).until(
+                EC.presence_of_element_located((By.TAG_NAME, "article"))
+            )
+        except:
+            print("[WARN] article not found")
+
+        time.sleep(1)
+        return self.driver.page_source
+
+    def collect_images(self):
+        img_urls = set()
+
+        try:
+            wrapper = WebDriverWait(self.driver, 10).until(
+                EC.presence_of_element_located((By.CSS_SELECTOR, "div[role='presentation']"))
+            )
+        except:
+            print("[ERROR] slider wrapper not found")
+            return []
+
+        while True:
+            time.sleep(0.8)
+            imgs = wrapper.find_elements(By.TAG_NAME, "img")
+            for img in imgs:
+                src = img.get_attribute("src")
+                if src and "scontent" in src:
+                    img_urls.add(src)
+
+            # next 버튼 클릭
+            try:
+                next_btn = self.driver.find_element(
+                    By.CSS_SELECTOR,
+                    "button[aria-label='Next'], button[aria-label='다음']"
+                )
+                next_btn.click()
+            except:
+                break
+
+        return list(img_urls)
+
+    def crawl(self, url: str) -> list[str]:
+        """전체 크롤링 플로우"""
+        self.fetch_html(url)
+        return self.collect_images()
+
+    def close(self):
+        self.driver.quit()

--- a/python-server/requirements.txt
+++ b/python-server/requirements.txt
@@ -1,2 +1,7 @@
 Flask
-selenium
+selenium==4.21.0
+undetected-chromedriver==3.5.5
+beautifulsoup4==4.12.2
+requests==2.31.0
+boto3
+python-dotenv

--- a/python-server/services/crawler_service.py
+++ b/python-server/services/crawler_service.py
@@ -1,0 +1,33 @@
+# services/crawler_service.py
+from crawler.instagram_crawler import InstagramCrawler
+from crawler.image_downloader import download_and_upload_to_s3
+import os
+
+class CrawlerService:
+
+    @staticmethod
+    def crawl_and_upload(url: str):
+        cookie_path = os.getenv("COOKIE_PATH")
+        crawler = InstagramCrawler(headless=True)
+        crawler.load_cookies(cookie_path)
+
+        # 1) 크롤링
+        image_urls = crawler.crawl(url)
+        crawler.close()
+
+        # 2) post_id 추출
+        try:
+            post_id = url.split("/p/")[1].split("/")[0]
+        except:
+            raise ValueError("Invalid Instagram post URL format")
+
+        # 3) S3 prefix 생성
+        prefix = f"instagram/posts/{post_id}"
+
+        # 4) 업로드
+        s3_keys = download_and_upload_to_s3(image_urls, prefix)
+
+        return {
+            "postId": post_id,
+            "images": s3_keys
+        }


### PR DESCRIPTION
## 🚩 관련 이슈
인스타 게시물 이미지 크롤링 + S3에 업로드

## 📢 작업 내용
- 파이썬 서버 구조 변경
- 크롤링 담당 crawler 구현

## 📸 스크린샷
<img width="1680" height="1050" alt="스크린샷 2025-11-29 오후 7 14 07" src="https://github.com/user-attachments/assets/8efbed2b-b4c6-4a36-be79-a4c97be0d8be" />
인스타 게시물은 
https://www.instagram.com/p/DRlZKh7jW1s/?utm_source=ig_web_copy_link&igsh=MzRlODBiNWFlZA==
이런 식으로 게시물 별로 /p/ 뒤에 postId가 존재하는데 이 postId 별로 버킷에 나눠 저장하고 postId를 반환하도록 함

<img width="1380" height="553" alt="스크린샷 2025-11-29 오후 7 16 03" src="https://github.com/user-attachments/assets/15b262d8-db7d-4e35-ad7d-8082e806b2a5" />
S3에 정상 업로드 확인

## ⚙️ 기타사항
- 노션에 .env랑 쿠키 올려놨으니 확인
- 파이썬 3.11로 돌려야 됨. 리드미 꼭 확인!!!!